### PR TITLE
Fix missing space in SQL statement

### DIFF
--- a/CRM/DoctorWhen/Cleanups/ConvertTimestamp.php
+++ b/CRM/DoctorWhen/Cleanups/ConvertTimestamp.php
@@ -44,9 +44,9 @@ class CRM_DoctorWhen_Cleanups_ConvertTimestamp extends CRM_DoctorWhen_Cleanups_B
    * @param array $options
    */
   public function enqueue(CRM_Queue_Queue $queue, $options) {
-    $sql = "ALTER TABLE {$this->table} CHANGE {$this->column} {$this->column} TIMESTAMP";
+    $sql = "ALTER TABLE {$this->table} CHANGE {$this->column} {$this->column} TIMESTAMP ";
     if (!empty($this->default)) {
-      $sql .= "NULL DEFAULT {$this->default}";
+      $sql .= " NULL DEFAULT {$this->default}";
     }
     $queue->createItem($this->createTask($this->getTitle(), 'executeQuery', $sql));
   }


### PR DESCRIPTION
Hi @totten.  On some sites the SQL is generated without a space between TIMESTAMP and NULL in the ALTER TABLE statement.   This PR adds a space...