### PR TITLE
Increment verson number

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -14,8 +14,8 @@
     <url desc="Support">http://FIXME</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2017-07-28</releaseDate>
-  <version>1.0</version>
+  <releaseDate>2017-12-17</releaseDate>
+  <version>1.1</version>
   <develStage>alpha</develStage>
   <compatibility>
     <ver>4.7</ver>


### PR DESCRIPTION
Because of people experiencing problems with Doctor When that have been fixed, I think it's important to give a version number so we can ask for it as part of providing user support.