### PR TITLE
Replace deprecated function

### DIFF
--- a/CRM/DoctorWhen/Cleanups/ActivityCreated.php
+++ b/CRM/DoctorWhen/Cleanups/ActivityCreated.php
@@ -3,7 +3,7 @@
 class CRM_DoctorWhen_Cleanups_ActivityCreated extends CRM_DoctorWhen_Cleanups_Base {
 
   public function isActive() {
-    return CRM_Core_DAO::checkFieldExists('civicrm_activity', 'created_date');
+    return CRM_Core_BAO_SchemaHandler::checkIfFieldExists('civicrm_activity', 'created_date');
   }
 
 

--- a/CRM/DoctorWhen/Cleanups/ActivityModified.php
+++ b/CRM/DoctorWhen/Cleanups/ActivityModified.php
@@ -3,7 +3,7 @@
 class CRM_DoctorWhen_Cleanups_ActivityModified extends CRM_DoctorWhen_Cleanups_Base {
 
   public function isActive() {
-    return CRM_Core_DAO::checkFieldExists('civicrm_activity', 'modified_date');
+    return CRM_Core_BAO_SchemaHandler::checkIfFieldExists('civicrm_activity', 'modified_date');
   }
 
   public function getTitle() {

--- a/CRM/DoctorWhen/Cleanups/CaseCreated.php
+++ b/CRM/DoctorWhen/Cleanups/CaseCreated.php
@@ -3,7 +3,7 @@
 class CRM_DoctorWhen_Cleanups_CaseCreated extends CRM_DoctorWhen_Cleanups_Base {
 
   public function isActive() {
-    return CRM_Core_DAO::checkFieldExists('civicrm_case', 'created_date');
+    return CRM_Core_BAO_SchemaHandler::checkIfFieldExists('civicrm_case', 'created_date');
   }
 
   public function getTitle() {

--- a/CRM/DoctorWhen/Cleanups/CaseModified.php
+++ b/CRM/DoctorWhen/Cleanups/CaseModified.php
@@ -3,7 +3,7 @@
 class CRM_DoctorWhen_Cleanups_CaseModified extends CRM_DoctorWhen_Cleanups_Base {
 
   public function isActive() {
-    return CRM_Core_DAO::checkFieldExists('civicrm_case', 'modified_date');
+    return CRM_Core_BAO_SchemaHandler::checkIfFieldExists('civicrm_case', 'modified_date');
   }
 
   public function getTitle() {

--- a/doctorwhen.civix.php
+++ b/doctorwhen.civix.php
@@ -24,7 +24,7 @@ class CRM_DoctorWhen_ExtensionUtil {
    *   Translated text.
    * @see ts
    */
-  public static function ts($text, $params = []) {
+  public static function ts($text, $params = []): string {
     if (!array_key_exists('domain', $params)) {
       $params['domain'] = [self::LONG_NAME, NULL];
     }
@@ -41,7 +41,7 @@ class CRM_DoctorWhen_ExtensionUtil {
    *   Ex: 'http://example.org/sites/default/ext/org.example.foo'.
    *   Ex: 'http://example.org/sites/default/ext/org.example.foo/css/foo.css'.
    */
-  public static function url($file = NULL) {
+  public static function url($file = NULL): string {
     if ($file === NULL) {
       return rtrim(CRM_Core_Resources::singleton()->getUrl(self::LONG_NAME), '/');
     }
@@ -84,40 +84,17 @@ use CRM_DoctorWhen_ExtensionUtil as E;
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_config
  */
-function _doctorwhen_civix_civicrm_config(&$config = NULL) {
+function _doctorwhen_civix_civicrm_config($config = NULL) {
   static $configured = FALSE;
   if ($configured) {
     return;
   }
   $configured = TRUE;
 
-  $template = CRM_Core_Smarty::singleton();
-
   $extRoot = __DIR__ . DIRECTORY_SEPARATOR;
-  $extDir = $extRoot . 'templates';
-
-  if (is_array($template->template_dir)) {
-    array_unshift($template->template_dir, $extDir);
-  }
-  else {
-    $template->template_dir = [$extDir, $template->template_dir];
-  }
-
   $include_path = $extRoot . PATH_SEPARATOR . get_include_path();
   set_include_path($include_path);
-}
-
-/**
- * (Delegated) Implements hook_civicrm_xmlMenu().
- *
- * @param $files array(string)
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_xmlMenu
- */
-function _doctorwhen_civix_civicrm_xmlMenu(&$files) {
-  foreach (_doctorwhen_civix_glob(__DIR__ . '/xml/Menu/*.xml') as $file) {
-    $files[] = $file;
-  }
+  // Based on <compatibility>, this does not currently require mixin/polyfill.php.
 }
 
 /**
@@ -127,35 +104,7 @@ function _doctorwhen_civix_civicrm_xmlMenu(&$files) {
  */
 function _doctorwhen_civix_civicrm_install() {
   _doctorwhen_civix_civicrm_config();
-  if ($upgrader = _doctorwhen_civix_upgrader()) {
-    $upgrader->onInstall();
-  }
-}
-
-/**
- * Implements hook_civicrm_postInstall().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_postInstall
- */
-function _doctorwhen_civix_civicrm_postInstall() {
-  _doctorwhen_civix_civicrm_config();
-  if ($upgrader = _doctorwhen_civix_upgrader()) {
-    if (is_callable([$upgrader, 'onPostInstall'])) {
-      $upgrader->onPostInstall();
-    }
-  }
-}
-
-/**
- * Implements hook_civicrm_uninstall().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_uninstall
- */
-function _doctorwhen_civix_civicrm_uninstall() {
-  _doctorwhen_civix_civicrm_config();
-  if ($upgrader = _doctorwhen_civix_upgrader()) {
-    $upgrader->onUninstall();
-  }
+  // Based on <compatibility>, this does not currently require mixin/polyfill.php.
 }
 
 /**
@@ -163,188 +112,9 @@ function _doctorwhen_civix_civicrm_uninstall() {
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_enable
  */
-function _doctorwhen_civix_civicrm_enable() {
+function _doctorwhen_civix_civicrm_enable(): void {
   _doctorwhen_civix_civicrm_config();
-  if ($upgrader = _doctorwhen_civix_upgrader()) {
-    if (is_callable([$upgrader, 'onEnable'])) {
-      $upgrader->onEnable();
-    }
-  }
-}
-
-/**
- * (Delegated) Implements hook_civicrm_disable().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_disable
- * @return mixed
- */
-function _doctorwhen_civix_civicrm_disable() {
-  _doctorwhen_civix_civicrm_config();
-  if ($upgrader = _doctorwhen_civix_upgrader()) {
-    if (is_callable([$upgrader, 'onDisable'])) {
-      $upgrader->onDisable();
-    }
-  }
-}
-
-/**
- * (Delegated) Implements hook_civicrm_upgrade().
- *
- * @param $op string, the type of operation being performed; 'check' or 'enqueue'
- * @param $queue CRM_Queue_Queue, (for 'enqueue') the modifiable list of pending up upgrade tasks
- *
- * @return mixed
- *   based on op. for 'check', returns array(boolean) (TRUE if upgrades are pending)
- *   for 'enqueue', returns void
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_upgrade
- */
-function _doctorwhen_civix_civicrm_upgrade($op, CRM_Queue_Queue $queue = NULL) {
-  if ($upgrader = _doctorwhen_civix_upgrader()) {
-    return $upgrader->onUpgrade($op, $queue);
-  }
-}
-
-/**
- * @return CRM_DoctorWhen_Upgrader
- */
-function _doctorwhen_civix_upgrader() {
-  if (!file_exists(__DIR__ . '/CRM/DoctorWhen/Upgrader.php')) {
-    return NULL;
-  }
-  else {
-    return CRM_DoctorWhen_Upgrader_Base::instance();
-  }
-}
-
-/**
- * Search directory tree for files which match a glob pattern.
- *
- * Note: Dot-directories (like "..", ".git", or ".svn") will be ignored.
- * Note: Delegate to CRM_Utils_File::findFiles(), this function kept only
- * for backward compatibility of extension code that uses it.
- *
- * @param string $dir base dir
- * @param string $pattern , glob pattern, eg "*.txt"
- *
- * @return array
- */
-function _doctorwhen_civix_find_files($dir, $pattern) {
-  return CRM_Utils_File::findFiles($dir, $pattern);
-}
-
-/**
- * (Delegated) Implements hook_civicrm_managed().
- *
- * Find any *.mgd.php files, merge their content, and return.
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_managed
- */
-function _doctorwhen_civix_civicrm_managed(&$entities) {
-  $mgdFiles = _doctorwhen_civix_find_files(__DIR__, '*.mgd.php');
-  sort($mgdFiles);
-  foreach ($mgdFiles as $file) {
-    $es = include $file;
-    foreach ($es as $e) {
-      if (empty($e['module'])) {
-        $e['module'] = E::LONG_NAME;
-      }
-      if (empty($e['params']['version'])) {
-        $e['params']['version'] = '3';
-      }
-      $entities[] = $e;
-    }
-  }
-}
-
-/**
- * (Delegated) Implements hook_civicrm_caseTypes().
- *
- * Find any and return any files matching "xml/case/*.xml"
- *
- * Note: This hook only runs in CiviCRM 4.4+.
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_caseTypes
- */
-function _doctorwhen_civix_civicrm_caseTypes(&$caseTypes) {
-  if (!is_dir(__DIR__ . '/xml/case')) {
-    return;
-  }
-
-  foreach (_doctorwhen_civix_glob(__DIR__ . '/xml/case/*.xml') as $file) {
-    $name = preg_replace('/\.xml$/', '', basename($file));
-    if ($name != CRM_Case_XMLProcessor::mungeCaseType($name)) {
-      $errorMessage = sprintf("Case-type file name is malformed (%s vs %s)", $name, CRM_Case_XMLProcessor::mungeCaseType($name));
-      throw new CRM_Core_Exception($errorMessage);
-    }
-    $caseTypes[$name] = [
-      'module' => E::LONG_NAME,
-      'name' => $name,
-      'file' => $file,
-    ];
-  }
-}
-
-/**
- * (Delegated) Implements hook_civicrm_angularModules().
- *
- * Find any and return any files matching "ang/*.ang.php"
- *
- * Note: This hook only runs in CiviCRM 4.5+.
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_angularModules
- */
-function _doctorwhen_civix_civicrm_angularModules(&$angularModules) {
-  if (!is_dir(__DIR__ . '/ang')) {
-    return;
-  }
-
-  $files = _doctorwhen_civix_glob(__DIR__ . '/ang/*.ang.php');
-  foreach ($files as $file) {
-    $name = preg_replace(':\.ang\.php$:', '', basename($file));
-    $module = include $file;
-    if (empty($module['ext'])) {
-      $module['ext'] = E::LONG_NAME;
-    }
-    $angularModules[$name] = $module;
-  }
-}
-
-/**
- * (Delegated) Implements hook_civicrm_themes().
- *
- * Find any and return any files matching "*.theme.php"
- */
-function _doctorwhen_civix_civicrm_themes(&$themes) {
-  $files = _doctorwhen_civix_glob(__DIR__ . '/*.theme.php');
-  foreach ($files as $file) {
-    $themeMeta = include $file;
-    if (empty($themeMeta['name'])) {
-      $themeMeta['name'] = preg_replace(':\.theme\.php$:', '', basename($file));
-    }
-    if (empty($themeMeta['ext'])) {
-      $themeMeta['ext'] = E::LONG_NAME;
-    }
-    $themes[$themeMeta['name']] = $themeMeta;
-  }
-}
-
-/**
- * Glob wrapper which is guaranteed to return an array.
- *
- * The documentation for glob() says, "On some systems it is impossible to
- * distinguish between empty match and an error." Anecdotally, the return
- * result for an empty match is sometimes array() and sometimes FALSE.
- * This wrapper provides consistency.
- *
- * @link http://php.net/glob
- * @param string $pattern
- *
- * @return array
- */
-function _doctorwhen_civix_glob($pattern) {
-  $result = glob($pattern);
-  return is_array($result) ? $result : [];
+  // Based on <compatibility>, this does not currently require mixin/polyfill.php.
 }
 
 /**
@@ -363,8 +133,8 @@ function _doctorwhen_civix_insert_navigation_menu(&$menu, $path, $item) {
   if (empty($path)) {
     $menu[] = [
       'attributes' => array_merge([
-        'label'      => CRM_Utils_Array::value('name', $item),
-        'active'     => 1,
+        'label' => $item['name'] ?? NULL,
+        'active' => 1,
       ], $item),
     ];
     return TRUE;
@@ -427,27 +197,4 @@ function _doctorwhen_civix_fixNavigationMenuItems(&$nodes, &$maxNavID, $parentID
       _doctorwhen_civix_fixNavigationMenuItems($nodes[$origKey]['child'], $maxNavID, $nodes[$origKey]['attributes']['navID']);
     }
   }
-}
-
-/**
- * (Delegated) Implements hook_civicrm_alterSettingsFolders().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_alterSettingsFolders
- */
-function _doctorwhen_civix_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
-  $settingsDir = __DIR__ . DIRECTORY_SEPARATOR . 'settings';
-  if (!in_array($settingsDir, $metaDataFolders) && is_dir($settingsDir)) {
-    $metaDataFolders[] = $settingsDir;
-  }
-}
-
-/**
- * (Delegated) Implements hook_civicrm_entityTypes().
- *
- * Find any *.entityType.php files, merge their content, and return.
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_entityTypes
- */
-function _doctorwhen_civix_civicrm_entityTypes(&$entityTypes) {
-  $entityTypes = array_merge($entityTypes, []);
 }

--- a/doctorwhen.php
+++ b/doctorwhen.php
@@ -12,39 +12,12 @@ function doctorwhen_civicrm_config(&$config) {
 }
 
 /**
- * Implements hook_civicrm_xmlMenu().
- *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_xmlMenu
- */
-function doctorwhen_civicrm_xmlMenu(&$files) {
-  _doctorwhen_civix_civicrm_xmlMenu($files);
-}
-
-/**
  * Implements hook_civicrm_install().
  *
  * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_install
  */
 function doctorwhen_civicrm_install() {
   _doctorwhen_civix_civicrm_install();
-}
-
-/**
- * Implements hook_civicrm_postInstall().
- *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_postInstall
- */
-function doctorwhen_civicrm_postInstall() {
-  _doctorwhen_civix_civicrm_postInstall();
-}
-
-/**
- * Implements hook_civicrm_uninstall().
- *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_uninstall
- */
-function doctorwhen_civicrm_uninstall() {
-  _doctorwhen_civix_civicrm_uninstall();
 }
 
 /**
@@ -56,72 +29,6 @@ function doctorwhen_civicrm_enable() {
   _doctorwhen_civix_civicrm_enable();
 }
 
-/**
- * Implements hook_civicrm_disable().
- *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_disable
- */
-function doctorwhen_civicrm_disable() {
-  _doctorwhen_civix_civicrm_disable();
-}
-
-/**
- * Implements hook_civicrm_upgrade().
- *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_upgrade
- */
-function doctorwhen_civicrm_upgrade($op, CRM_Queue_Queue $queue = NULL) {
-  return _doctorwhen_civix_civicrm_upgrade($op, $queue);
-}
-
-/**
- * Implements hook_civicrm_managed().
- *
- * Generate a list of entities to create/deactivate/delete when this module
- * is installed, disabled, uninstalled.
- *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_managed
- */
-function doctorwhen_civicrm_managed(&$entities) {
-  _doctorwhen_civix_civicrm_managed($entities);
-}
-
-/**
- * Implements hook_civicrm_caseTypes().
- *
- * Generate a list of case-types.
- *
- * Note: This hook only runs in CiviCRM 4.4+.
- *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_caseTypes
- */
-function doctorwhen_civicrm_caseTypes(&$caseTypes) {
-  _doctorwhen_civix_civicrm_caseTypes($caseTypes);
-}
-
-/**
- * Implements hook_civicrm_angularModules().
- *
- * Generate a list of Angular modules.
- *
- * Note: This hook only runs in CiviCRM 4.5+. It may
- * use features only available in v4.6+.
- *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_angularModules
- */
-function doctorwhen_civicrm_angularModules(&$angularModules) {
-  _doctorwhen_civix_civicrm_angularModules($angularModules);
-}
-
-/**
- * Implements hook_civicrm_alterSettingsFolders().
- *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_alterSettingsFolders
- */
-function doctorwhen_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
-  _doctorwhen_civix_civicrm_alterSettingsFolders($metaDataFolders);
-}
-
 // --- Functions below this ship commented out. Uncomment as required. ---
 
 /**
@@ -129,9 +36,8 @@ function doctorwhen_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
  *
  * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_preProcess
  *
-function doctorwhen_civicrm_preProcess($formName, &$form) {
 
-} // */
+ // */
 
 /**
  * Implements hook_civicrm_navigationMenu().

--- a/info.xml
+++ b/info.xml
@@ -17,9 +17,18 @@
   <version>1.2</version>
   <develStage>stable</develStage>
   <compatibility>
-    <ver>5.0</ver>
+    <ver>5.60</ver>
   </compatibility>
   <civix>
     <namespace>CRM/DoctorWhen</namespace>
+    <format>23.02.1</format>
   </civix>
+  <mixins>
+    <mixin>menu-xml@1.0.0</mixin>
+    <mixin>smarty-v2@1.0.1</mixin>
+  </mixins>
+  <classloader>
+    <psr0 prefix="CRM_" path="."/>
+    <psr4 prefix="Civi\" path="Civi"/>
+  </classloader>
 </extension>


### PR DESCRIPTION
Replace the deprecated and removed function `CRM_Core_DAO::checkFieldExists()` with its replacement `CRM_Core_BAO_SchemaHandler::checkIfFieldExists()`

Run `civix upgrade`